### PR TITLE
Add return_result option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # A Log of Changes!
 
+## [0.2.0] - 2019-10-11
+
+- Return the result evaluated inside the block
+
 ## [0.1.2] - 2017-12-06
 
 - Support Rails 5 and newer PG versions [#5]

--- a/lib/pg_lock.rb
+++ b/lib/pg_lock.rb
@@ -27,12 +27,13 @@ class PgLock
   end
   UnableToLock = UnableToLockError
 
-  def initialize(name:, attempts: 3, attempt_interval: 1, ttl: 60, connection: DEFAULT_CONNECTION_CONNECTOR.call, log: DEFAULT_LOGGER.call )
+  def initialize(name:, attempts: 3, attempt_interval: 1, ttl: 60, connection: DEFAULT_CONNECTION_CONNECTOR.call, log: DEFAULT_LOGGER.call, return_result: false)
     self.name               = name
     self.max_attempts       = [attempts, 1].max
     self.attempt_interval   = attempt_interval
     self.ttl                = ttl || 0 # set this to 0 to disable the timeout
     self.log                = log
+    self.return_result      = return_result
 
     connection or raise "Must provide a valid connection object"
     self.locket             = Locket.new(connection, [PG_LOCK_SPACE, key(name)])
@@ -41,12 +42,13 @@ class PgLock
   # Runs the given block if an advisory lock is able to be acquired.
   def lock(&block)
     if create
+      result = nil
       begin
-        Timeout::timeout(ttl, &block) if block_given?
+        result = Timeout::timeout(ttl, &block) if block_given?
       ensure
         delete
       end
-      return true
+      return_result ? result : true
     else
       return false
     end
@@ -97,6 +99,7 @@ class PgLock
     attr_accessor :ttl
     attr_accessor :name
     attr_accessor :log
+    attr_accessor :return_result
 
     def key(name)
       i = Zlib.crc32(name.to_s)

--- a/lib/pg_lock.rb
+++ b/lib/pg_lock.rb
@@ -27,7 +27,7 @@ class PgLock
   end
   UnableToLock = UnableToLockError
 
-  def initialize(name:, attempts: 3, attempt_interval: 1, ttl: 60, connection: DEFAULT_CONNECTION_CONNECTOR.call, log: DEFAULT_LOGGER.call, return_result: false)
+  def initialize(name:, attempts: 3, attempt_interval: 1, ttl: 60, connection: DEFAULT_CONNECTION_CONNECTOR.call, log: DEFAULT_LOGGER.call, return_result: true)
     self.name               = name
     self.max_attempts       = [attempts, 1].max
     self.attempt_interval   = attempt_interval

--- a/spec/pg_lock_spec.rb
+++ b/spec/pg_lock_spec.rb
@@ -29,6 +29,11 @@ describe PgLock do
     fails_to_lock.lock {}
   end
 
+  it 'return_result' do
+    key  = testing_key("return_result")
+    expect(PgLock.new(name: key, return_result: true).lock { 'result' }).to eq('result')
+  end
+
   it "ttl" do
     key  = testing_key("ttl")
     time = rand(2..4)


### PR DESCRIPTION
First of all thanks for maintaining and open sourcing this Gem!

I've just started using it and I found out might be a good idea to add the possibility to return the result by specifying a flag. For example:

````ruby
PgLock.new(name: 'user').lock { User.create(name: 'testing) } 
=> true
````
With the current implementation I have to create a variable in order to return, something like this: 

````ruby
result = nil
PgLock.new(name: 'user').lock { result = User.create(name: 'testing) } 
=> result 
#<User....
````
PS:. I've implemented this way in a project I'm working on.

My proposal is to add the `return_result` flag which makes possible to return the value evaluated inside the lock.

````ruby
PgLock.new(name: 'user', return_result: true).lock { result = User.create(name: 'testing) } 
#<User....
````

I'm not sure if it's useful for everybody but for me it is. If you think it's a good idea just let me know I can add the docs for that.

Thanks for your time!
