### PR TITLE
add #acquired? with correct spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,13 +119,13 @@ ensure
 end
 ```
 
-You can check on the status of a lock with the `aquired?` method:
+You can check on the status of a lock with the `acquired?` method:
 
 ```ruby
 begin
   lock = PgLock.new(name: "all_your_base")
   lock.create
-  if lock.aquired?
+  if lock.acquired?
     # do stuff
   end
 ensure

--- a/lib/pg_lock.rb
+++ b/lib/pg_lock.rb
@@ -79,9 +79,16 @@ class PgLock
     end
   end
 
+  # Left the misspelled version of this method for backwards compatibility
   def aquired?
+    acquired?
+  end
+
+  def acquired?
     locket.active?
   end
+
+  alias :has_lock? :acquired?
   alias :has_lock? :aquired?
 
   private def internal_lock(&block)

--- a/lib/pg_lock/locket.rb
+++ b/lib/pg_lock/locket.rb
@@ -11,7 +11,7 @@ class PgLock
 
     def lock
       @lock = connection.exec("select pg_try_advisory_lock($1,$2)", args)
-      return aquired?
+      return acquired?
     end
 
     def unlock
@@ -19,10 +19,15 @@ class PgLock
       @lock = false
     end
 
-    def aquired?
+    def acquired?
       TRUE_VALUES.include?(@lock[0]["pg_try_advisory_lock"])
     rescue
       false
+    end
+
+    # Left the misspelled version of this method for backwards compatibility
+    def aquired?
+      acquired?
     end
 
     def active?

--- a/spec/pg_lock_spec.rb
+++ b/spec/pg_lock_spec.rb
@@ -73,6 +73,19 @@ describe PgLock do
     end
   end
 
+  it "acquires correctly" do
+    key = testing_key("acquired_test")
+
+    begin
+      lock = PgLock.new(name: key).create
+
+      expect(lock.acquired?).to be true
+      expect(lock.aquired?).to be true
+    ensure
+      lock.delete
+    end
+  end
+
   it "only runs X times" do
     begin
       count = rand(2..9)


### PR DESCRIPTION
It looks like the `aquired?` method is misspelled, seems a bit pedantic, but it sent me on a heck of a wild goose chase, so I figured I would add in the correct spelling for the method. I kept the original spelling as an alias method so the change should be entirely compatible with any existing code.