### PR TITLE
Delete lock when exception is raised in logging block

### DIFF
--- a/lib/pg_lock.rb
+++ b/lib/pg_lock.rb
@@ -89,7 +89,6 @@ class PgLock
   end
 
   alias :has_lock? :acquired?
-  alias :has_lock? :aquired?
 
   private def internal_lock(&block)
     if create

--- a/lib/pg_lock.rb
+++ b/lib/pg_lock.rb
@@ -94,15 +94,13 @@ class PgLock
   private def internal_lock(&block)
     if create
       result = nil
-      begin
-        result = Timeout::timeout(ttl, &block) if block_given?
-      ensure
-        delete
-      end
+      result = Timeout::timeout(ttl, &block) if block_given?
       return_result ? result : true
     else
       return NO_LOCK
     end
+  ensure
+    delete if locket.acquired?
   end
 
   private

--- a/lib/pg_lock/locket.rb
+++ b/lib/pg_lock/locket.rb
@@ -31,16 +31,20 @@ class PgLock
     end
 
     def active?
-      active = connection.exec(<<-eos, args).getvalue(0,0)
+      query = <<-eos
         SELECT granted
         FROM pg_locks
         WHERE locktype = 'advisory' AND
-         pid = pg_backend_pid() AND
-         mode = 'ExclusiveLock' AND
-         classid = $1 AND
-         objid = $2
+        pid = pg_backend_pid() AND
+        mode = 'ExclusiveLock' AND
+        classid = $1 AND
+        objid = $2
       eos
 
+      result = connection.exec(query, args)
+      return false if result.ntuples == 0
+
+      active = result.getvalue(0,0)
       TRUE_VALUES.include?(active)
     end
   end

--- a/spec/pg_lock_spec.rb
+++ b/spec/pg_lock_spec.rb
@@ -131,4 +131,20 @@ describe PgLock do
     expect(lock.acquired?).to be false
     expect(lock.aquired?).to be false
   end
+
+  it 'is unlocked when exception is raised during logging' do
+    exception = Class.new(StandardError)
+    key = testing_key("log_exception_test")
+
+    begin
+      lock = PgLock.new(name: key, log: -> (_) { raise exception })
+      lock.lock do
+        puts 1
+      end
+    rescue exception
+      expect(lock.acquired?).to be false
+    ensure
+      # PgLock.new(name: key).delete
+    end
+  end
 end

--- a/spec/pg_lock_spec.rb
+++ b/spec/pg_lock_spec.rb
@@ -121,4 +121,14 @@ describe PgLock do
     end
     expect(true).to eq(true)
   end
+
+  it 'returns false from acquired? when lock is not acquired' do
+    key = testing_key('not_acquired_test')
+
+    lock = PgLock.new(name: key)
+    acquired = lock.acquired?
+
+    expect(lock.acquired?).to be false
+    expect(lock.aquired?).to be false
+  end
 end


### PR DESCRIPTION
This PR fixes issue where lock remained acquired when exception was raised when calling logging block.

It also fixes calling `PgLock#acquired?` when lock is not acquired. Before it threw an exception because PgResult didn't have any tuples.

Tests are added for both issues.